### PR TITLE
Set up local development with Kubernetes and deployment scripts

### DIFF
--- a/k8s/local/deployment.yaml
+++ b/k8s/local/deployment.yaml
@@ -1,0 +1,116 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: eagle-bank-local
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eagle-bank-config
+  namespace: eagle-bank-local
+data:
+  SPRING_PROFILES_ACTIVE: "local"
+  DB_NAME: "eaglebank"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: eagle-bank-secrets
+  namespace: eagle-bank-local
+type: Opaque
+data:
+  DB_PASSWORD: eW91cl9zZWN1cmVfcGFzc3dvcmQ=  # your_secure_password
+  DB_USER: ZWFnbGViYW5rX3VzZXI=             # eaglebank_user
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eagle-bank-db
+  namespace: eagle-bank-local
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: eagle-bank-db
+  template:
+    metadata:
+      labels:
+        app: eagle-bank-db
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:16
+        ports:
+        - containerPort: 5432
+        env:
+        - name: POSTGRES_DB
+          value: eaglebank
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: eagle-bank-secrets
+              key: DB_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: eagle-bank-secrets
+              key: DB_PASSWORD
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: eagle-bank-db
+  namespace: eagle-bank-local
+spec:
+  selector:
+    app: eagle-bank-db
+  ports:
+  - port: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eagle-bank
+  namespace: eagle-bank-local
+spec:
+  replicas: 1  # Single replica for local development
+  selector:
+    matchLabels:
+      app: eagle-bank
+  template:
+    metadata:
+      labels:
+        app: eagle-bank
+    spec:
+      containers:
+      - name: eagle-bank
+        image: eagle-bank:latest  # We'll build this locally
+        imagePullPolicy: Never   # Important for local development
+        ports:
+        - containerPort: 8080
+        env:
+        - name: SPRING_DATASOURCE_URL
+          value: jdbc:postgresql://eagle-bank-db:5432/eaglebank
+        - name: SPRING_DATASOURCE_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: eagle-bank-secrets
+              key: DB_USER
+        - name: SPRING_DATASOURCE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: eagle-bank-secrets
+              key: DB_PASSWORD
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: eagle-bank
+  namespace: eagle-bank-local
+spec:
+  type: LoadBalancer  # This makes it accessible locally
+  selector:
+    app: eagle-bank
+  ports:
+  - port: 8080
+    targetPort: 8080

--- a/local-deply.sh
+++ b/local-deply.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Build the application and Docker image
+./gradlew clean build
+docker build -t eagle-bank:latest .
+
+# Apply Kubernetes configurations
+kubectl apply -f k8s/local/deployment.yaml
+
+# Wait for pods to be ready
+echo "Waiting for pods to be ready..."
+kubectl wait --namespace=eagle-bank-local \
+  --for=condition=ready pod \
+  --selector=app=eagle-bank \
+  --timeout=300s
+
+# Get the service URL
+echo "Application is running!"
+if [ "$(command -v minikube)" ]; then
+    echo "Access the application at: $(minikube service eagle-bank -n eagle-bank-local --url)"
+else
+    echo "Access the application at: http://localhost:8080"
+fi


### PR DESCRIPTION
- Added `local-deploy.sh` for building, deploying, and accessing the application locally.
- Introduced Kubernetes YAML files for local namespace, ConfigMaps, Secrets, Deployments, and Services.
- Configured PostgreSQL and application containers with environment variable injection via ConfigMaps and Secrets.